### PR TITLE
Expose template as flake attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # pydev
 
 A `flake-parts` module to setup an opinionated development environment for working on Python packages.
+
+Get started with the template with:
+
+##
+        nix flake init --template github:oceansprint/pydev

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
   outputs = inputs@{ flake-parts, nixpkgs, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } ({self, ...}:{
       flake.flakeModule = import ./flake-module.nix {pydev=self;};
+      flake.templates.default = {path=./template;};
       systems = [];
     });
 


### PR DESCRIPTION
This allows users to setup your template with:

`nix flake init --template github:oceansprint/pydev`